### PR TITLE
Add simple HTTP server which will be used to return GPS data to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Server prerequisites
+- `sudo apt install nodejs`
+- `sudo apt install npm`
+- `sudo apt install redis-server`
+
 # How to deploy
 1. First time only:
 	1. If not already done, copy the `secret_examples/` folder to `secret/` (the latter is ignored by Git)

--- a/app.js
+++ b/app.js
@@ -1,37 +1,6 @@
-const Parser = require('teltonika-parser-ex');
-const binutils = require('binutils64');
-const net = require('net');
+import SocketServer from './socket_server.js';
+import HttpServer from './http_server.js';
 
 
-let server = net.createServer((c) => {
-        console.log("client connected");
-        c.on('end', () => {
-        console.log("client disconnected");
-        });
-
-        c.on('data', (data) => {
-
-                let buffer = data;
-                let parser = new Parser(buffer);
-                if(parser.isImei){
-                        c.write(Buffer.alloc(1, 1));
-                } else {
-                        let avl = parser.getAvl();
-
-                        let writer = new binutils.BinaryWriter();
-                        writer.WriteInt32(avl.number_of_data);
-
-                        let response = writer.ByteBuffer;
-                        c.write(response);
-                }
-
-                const avl = parser.getAvl();
-                if(typeof avl.records !== "undefined" && avl.number_of_data > 0) {
-                        console.log(avl.records.at(-1).gps);
-                }
-        });
-});
-
-server.listen(3636, () => {
-        console.log("Server started");
-});
+new SocketServer(3636);
+new HttpServer(8080);

--- a/data_store.js
+++ b/data_store.js
@@ -1,0 +1,30 @@
+import { createClient } from 'redis';
+
+
+const DataStore = (function () {
+  var redisClient;
+
+  async function createRedisClient() {
+    const client = await createClient()
+    .on('error', err => console.log('Redis Client Error', err))
+    .connect();
+    
+    return client;
+  }
+  
+  function normalizedValue(value) {
+    return typeof value === "object" ? JSON.stringify(value) : value;
+  }
+
+  return {
+    put: async function (key, value) {
+      if (!redisClient) {
+        redisClient = await createRedisClient();
+      }
+
+      await redisClient.set(key, normalizedValue(value));
+    }
+  };
+})();
+
+export default DataStore;

--- a/http_server.js
+++ b/http_server.js
@@ -1,0 +1,41 @@
+import http from 'http';
+
+import DataStore from './data_store.js';
+
+
+class HttpServer {
+  constructor(port) {
+    const httpServer = http.createServer();
+
+    httpServer.on('request', (request, response) => {
+      const method = request.method;
+      const path = request.url;
+      let responseCode = null;
+      let responseData = null;
+      
+      if (method === "GET" && path === "/gps_location") {
+        [responseCode, responseData] = this.getGpsLocationAction();
+      }
+      else {
+        [responseCode, responseData] = [404, null];
+      }
+
+      this.renderResponse(response, responseCode, responseData);
+    });
+
+    httpServer.listen(port);
+  }
+  
+  renderResponse(response, code, data) {
+    response.writeHead(code, { 'Content-Type': 'application/json' });
+    const renderedData = data === null ? null : JSON.stringify({ data: data });
+    response.end(renderedData);
+  }
+  
+  getGpsLocationAction() {
+    // TBD
+    return [404, null];
+  }
+}
+
+export default HttpServer;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
+  "type": "module",
   "dependencies": {
-    "teltonika-parser-ex": "^0.0.16"
+    "teltonika-parser-ex": "^0.0.16",
+    "redis": "^4.6.10"
   }
 }

--- a/socket_server.js
+++ b/socket_server.js
@@ -1,0 +1,57 @@
+import binutils from 'binutils64';
+import net from 'net';
+import Parser from 'teltonika-parser-ex';
+
+import DataStore from './data_store.js';
+
+
+class SocketServer {
+  constructor(port) {
+    this.__server = net.createServer((c) => {
+      console.log("client connected");
+      c.on('end', this.onEnd);
+      c.on('data', (data) => { this.onData(data, c); });
+    });
+
+    this.__server.listen(port, () => {
+      console.log("Server started");
+    });
+  }
+
+  onEnd() {
+    console.log("client disconnected");
+  }
+
+  async onData(data, c) {
+    let buffer = data;
+    let parser = new Parser(buffer);
+    if (parser.isImei) {
+      c.write(Buffer.alloc(1, 1));
+    } else {
+      let avl = parser.getAvl();
+
+      let writer = new binutils.BinaryWriter();
+      writer.WriteInt32(avl.number_of_data);
+
+      let response = writer.ByteBuffer;
+      c.write(response);
+    }
+
+    const avl = parser.getAvl();
+    if (typeof avl.records === "undefined" || avl.number_of_data === 0) {
+      return;
+    }
+
+    const gpsInfo = avl.records.at(-1).gps;
+    if (typeof gpsInfo === "undefined" || typeof gpsInfo.longitude === "undefined") {
+      console.warn("Got empty GPS info");
+      return;
+    }
+
+    console.log(gpsInfo);
+    const location = { longitude: gpsInfo.longitude, latitude: gpsInfo.latitude };
+    await DataStore.put('location', location);
+  }
+}
+
+export default SocketServer;


### PR DESCRIPTION
After the failed attempt to have a Nest.js server (see [nestjs branch](https://github.com/TanguyP/hospital-eta-backend/tree/nestjs)) used both to (a) receive GPS updates from the tracker and (b) return GPS data to the frontend, I'm following an easier approach for now: because we already have part (a) working with native Node libraries, I've implemented (b) using native libraries as well. It will work for this POC because the endpoint we need is simple. However, if the POC were to be expanded, this would need to be refactored so as to use a proper web framework such as Nest.js, to keep things organised.